### PR TITLE
Fix input names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ jobs:
 | -------------------------- | -------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `environment`              | `false`  | None                         | Name of the environment, e.g. `development`, `production` (won't be included in the card if none)                       |
 | `timezone`                 | `false`  | `"UTC"`                      | A [valid database timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. `Australia/Sydney` |
-| `enable-view-status`       | `false`  | `true`                       | Enable an action to view the deployment status                                                                          |
-| `enable-review-diffs`      | `false`  | `true`                       | Enable an action to review commit diffs                                                                                 |
+| `enable-view-status-action`       | `false`  | `true`                       | Enable an action to view the deployment status                                                                          |
+| `enable-review-diffs-action`      | `false`  | `true`                       | Enable an action to review commit diffs                                                                                 |
 | `view-status-action-text`  | `false`  | `"View build/deploy status"` | Customize action text in viewing the deployment status                                                                  |
 | `review-diffs-action-text` | `false`  | `"Review commit diffs"`      | Customize action text in reviewing commit diffs                                                                         |
 | `custom-actions`           | `false`  | `null`                       | Add more actions; must be a YAML-parseable multiline string with `text` and `url` pairs                                 |


### PR DESCRIPTION
Based on warnings that GitHub showed me, when using the action (trying to use `enable-review-diffs` as an option as shown in the README) in one of my workflows:
![image](https://user-images.githubusercontent.com/22977266/115826623-7cc7da80-a40b-11eb-9744-75dd5af0fb81.png)

Here's the fix for the README :) 