### PR TITLE
docs: README: Update certain configs to correct names

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ jobs:
 
 #### Cozy and Complete Layout-specific Configurations
 
-| Name                       | Required | Default                      | Description                                                                                                             |
-| -------------------------- | -------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `environment`              | `false`  | None                         | Name of the environment, e.g. `development`, `production` (won't be included in the card if none)                       |
-| `timezone`                 | `false`  | `"UTC"`                      | A [valid database timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. `Australia/Sydney` |
-| `enable-view-status`       | `false`  | `true`                       | Enable an action to view the deployment status                                                                          |
-| `enable-review-diffs`      | `false`  | `true`                       | Enable an action to review commit diffs                                                                                 |
-| `view-status-action-text`  | `false`  | `"View build/deploy status"` | Customize action text in viewing the deployment status                                                                  |
-| `review-diffs-action-text` | `false`  | `"Review commit diffs"`      | Customize action text in reviewing commit diffs                                                                         |
-| `custom-actions`           | `false`  | `null`                       | Add more actions; must be a YAML-parseable multiline string with `text` and `url` pairs                                 |
+| Name                         | Required | Default                      | Description                                                                                                             |
+| ---------------------------- | -------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `environment`                | `false`  | None                         | Name of the environment, e.g. `development`, `production` (won't be included in the card if none)                       |
+| `timezone`                   | `false`  | `"UTC"`                      | A [valid database timezone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. `Australia/Sydney` |
+| `enable-view-status-action`  | `false`  | `true`                       | Enable an action to view the deployment status                                                                          |
+| `enable-review-diffs-action` | `false`  | `true`                       | Enable an action to review commit diffs                                                                                 |
+| `view-status-action-text`    | `false`  | `"View build/deploy status"` | Customize action text in viewing the deployment status                                                                  |
+| `review-diffs-action-text`   | `false`  | `"Review commit diffs"`      | Customize action text in reviewing commit diffs                                                                         |
+| `custom-actions`             | `false`  | `null`                       | Add more actions; must be a YAML-parseable multiline string with `text` and `url` pairs                                 |
 
 #### Complete Layout-specific Configurations
 


### PR DESCRIPTION
Update the README for `enable-view-status-action` and `enable-review-diffs-action` config options to the correct names.

They were reported as warnings in the Action.  The warning also showed the list of valid ones.

![image](https://user-images.githubusercontent.com/1796078/224129955-8294a83e-ae3e-4dc4-ae67-b22cd87ef07e.png)
